### PR TITLE
CI and config file support

### DIFF
--- a/flake8_html/__init__.py
+++ b/flake8_html/__init__.py
@@ -3,7 +3,7 @@
 
 __author__ = """Daniel Pope"""
 __email__ = 'mauve@mauveweb.co.uk'
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 
 from .plugin import HTMLPlugin

--- a/flake8_html/__init__.py
+++ b/flake8_html/__init__.py
@@ -3,7 +3,7 @@
 
 __author__ = """Daniel Pope"""
 __email__ = 'mauve@mauveweb.co.uk'
-__version__ = '0.3.1'
+__version__ = '0.4.0'
 
 
 from .plugin import HTMLPlugin

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -13,7 +13,7 @@ import os.path
 import codecs
 import datetime
 import pkgutil
-import ConfigParser
+import configparser
 
 from operator import attrgetter
 from collections import namedtuple, Counter
@@ -31,7 +31,7 @@ jinja2_env = Environment(
 )
 jinja2_env.filters['sentence'] = lambda s: s[:1].upper() + s[1:]
 
-config = ConfigParser.RawConfigParser()
+config = configparser.RawConfigParser()
 config.read(['setup.cfg', 'tox.ini', '.flake8'])
 #: A sequence of error code prefixes
 #:
@@ -83,10 +83,7 @@ class HTMLPlugin(base.BaseFormatter):
             self.outdir = self.options.htmldir
 
         if not self.options.htmlpep8:
-            try:
-                self.pep8report = config.get('flake8', 'htmlpep8')
-            except:
-                self.pep8report = False
+            self.pep8report = config.get('flake8', 'htmlpep8', fallback=False)
         else:
             self.pep8report = self.options.htmlpep8
 

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -151,7 +151,7 @@ class HTMLPlugin(base.BaseFormatter):
                 errs
             ))
             for err in errors:
-                print('%s:%d:%d %s %s' % (
+                print('%s:%d:%d: %s %s' % (
                     err.filename, err.line_number, err.column_number,
                     err.code, err.text
                 ))

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -157,14 +157,12 @@ class HTMLPlugin(base.BaseFormatter):
                 errs
             ))
             if self.pep8report:
-                perrs = []
                 for err in errors:
-                    perrs.append(
+                    pep8_report_errs.append(
                         (
                             err.filename, err.line_number, err.column_number,
                             err.code, err.text
                         ))
-                pep8_report_errs.extend(perrs)
         if self.pep8report:
             pep8_report_errs.sort(key=lambda err: (err[0], err[1], err[2]))
             for e in pep8_report_errs:

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -69,6 +69,7 @@ IndexEntry = namedtuple(
 
 class HTMLPlugin(base.BaseFormatter):
     """A plugin for flake8 to render errors as HTML reports."""
+
     def after_init(self):
         """Configure the plugin run."""
         self.report_template = jinja2_env.get_template('file-report.html')
@@ -209,7 +210,7 @@ class HTMLPlugin(base.BaseFormatter):
         rendered = self.source_template.render(**params)
         with codecs.open(source_filename, 'w', encoding='utf8') as f:
             f.write(rendered)
-
+        # stop() isn't called when, f.ex. called via some CI runners, so call it
         self.stop()
 
     def get_report_filename(self, filename, suffix=''):
@@ -289,8 +290,7 @@ class HTMLPlugin(base.BaseFormatter):
         cls.option_manager = options
         options.add_option(
             '--htmldir',
-            help="Directory in which to write HTML output.",
-            default="reports/flake-report"
+            help="Directory in which to write HTML output."
         )
         options.add_option(
             '--htmltitle',

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -188,6 +188,8 @@ class HTMLPlugin(base.BaseFormatter):
         with codecs.open(source_filename, 'w', encoding='utf8') as f:
             f.write(rendered)
 
+        self.stop()
+
     def get_report_filename(self, filename, suffix=''):
         """Generate a path in the output directory for the source file given.
 

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -82,13 +82,13 @@ class HTMLPlugin(base.BaseFormatter):
         else:
             self.outdir = self.options.htmldir
 
-        if not self.options.pylintreport:
+        if not self.options.htmlpylint:
             try:
-                self.pylintreport = config.get('flake8', 'html_pylint')
+                self.pylintreport = config.get('flake8', 'htmlpylint')
             except:
                 self.pylintreport = False
         else:
-            self.pylintreport = self.options.pylintreport
+            self.pylintreport = self.options.htmlpylint
 
         if not os.path.isdir(self.outdir):
             os.mkdir(self.outdir)
@@ -298,7 +298,7 @@ class HTMLPlugin(base.BaseFormatter):
             default="flake8 violations"
         )
         options.add_option(
-            '--pylintreport',
+            '--htmlpylint',
             help="Whether to create a pylint report instead of the standard one",
             default=False
         )

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -32,8 +32,7 @@ jinja2_env = Environment(
 jinja2_env.filters['sentence'] = lambda s: s[:1].upper() + s[1:]
 
 config = ConfigParser.RawConfigParser()
-config.read('setup.cfg')
-
+config.read(['setup.cfg', 'tox.ini', '.flake8'])
 #: A sequence of error code prefixes
 #:
 #: The first matching prefix determines the severity
@@ -70,7 +69,6 @@ IndexEntry = namedtuple(
 
 class HTMLPlugin(base.BaseFormatter):
     """A plugin for flake8 to render errors as HTML reports."""
-
     def after_init(self):
         """Configure the plugin run."""
         self.report_template = jinja2_env.get_template('file-report.html')

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -82,13 +82,13 @@ class HTMLPlugin(base.BaseFormatter):
         else:
             self.outdir = self.options.htmldir
 
-        if not self.options.htmlpylint:
+        if not self.options.htmlpep8:
             try:
-                self.pylintreport = config.get('flake8', 'htmlpylint')
+                self.pep8report = config.get('flake8', 'htmlpep8')
             except:
-                self.pylintreport = False
+                self.pep8report = False
         else:
-            self.pylintreport = self.options.htmlpylint
+            self.pep8report = self.options.htmlpep8
 
         if not os.path.isdir(self.outdir):
             os.mkdir(self.outdir)
@@ -122,7 +122,7 @@ class HTMLPlugin(base.BaseFormatter):
 
         with open(filename, 'rb') as f:
             source = f.read()
-        if not self.pylintreport:
+        if not self.pep8report:
             orig_filename = filename
         filename = re.sub(r'^\./', '', filename)
 
@@ -159,7 +159,7 @@ class HTMLPlugin(base.BaseFormatter):
                 unique_messages > 1 or any(e[2] > 1 for e in errs),
                 errs
             ))
-            if self.pylintreport:
+            if self.pep8report:
                 perrs = []
                 for err in errors:
                     perrs.append(
@@ -168,7 +168,7 @@ class HTMLPlugin(base.BaseFormatter):
                             err.code, err.text
                         ))
                 pep8_report_errs.extend(perrs)
-        if self.pylintreport:
+        if self.pep8report:
             pep8_report_errs.sort(key=lambda err: (err[0], err[1], err[2]))
             for e in pep8_report_errs:
                 print("%s:%d:%d: %s %s" % e)
@@ -179,7 +179,7 @@ class HTMLPlugin(base.BaseFormatter):
             scores.append(
                 '%s: %d' % (SEVERITY_NAMES[sev - 1], count)
             )
-        if not self.pylintreport:
+        if not self.pep8report:
             print(orig_filename, "has issues:", *scores)
 
         # Build a mapping of errors by line
@@ -298,7 +298,7 @@ class HTMLPlugin(base.BaseFormatter):
             default="flake8 violations"
         )
         options.add_option(
-            '--htmlpylint',
-            help="Whether to create a pylint report instead of the standard one",
+            '--htmlpep8',
+            help="Whether to create a pep8 report instead of the standard one",
             default=False
         )

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -158,7 +158,10 @@ class HTMLPlugin(base.BaseFormatter):
                 err.filename, err.line_number, err.column_number))
             # Step 3: Profit. Print the errors in pep8 report format
             for e in pep8_report_errs:
-                print("{e.filename}:{e.line_number}:{e.column_number} {e.code} {e.text}".format(e=e))
+                print((
+                    "{e.filename}:{e.line_number}:{e.column_number} "
+                    "{e.code} {e.text}"
+                ).format(e=e))
 
         index.sort(key=lambda r: (r[0], -r[1], r[2]))
 
@@ -198,8 +201,6 @@ class HTMLPlugin(base.BaseFormatter):
         rendered = self.source_template.render(**params)
         with codecs.open(source_filename, 'w', encoding='utf8') as f:
             f.write(rendered)
-        # stop() isn't called when, f.ex. called via some CI runners, so call it
-        self.stop()
 
     def get_report_filename(self, filename, suffix=''):
         """Generate a path in the output directory for the source file given.

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -157,16 +157,23 @@ class HTMLPlugin(base.BaseFormatter):
                 errs
             ))
             if self.pep8report:
+                # pep8 report - Step 1: gather errors
                 for err in errors:
                     pep8_report_errs.append(
                         (
                             err.filename, err.line_number, err.column_number,
                             err.code, err.text
-                        ))
+                        )
+                    )
+
         if self.pep8report:
+            # pep8 report - Step 2: sort gathered errors by
+            # filename, line- and column number
             pep8_report_errs.sort(key=lambda err: (err[0], err[1], err[2]))
+            # Step 3: Profit. Print the errors in pep8 report format
             for e in pep8_report_errs:
                 print("%s:%d:%d: %s %s" % e)
+
         index.sort(key=lambda r: (r[0], -r[1], r[2]))
 
         scores = []

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -151,12 +151,9 @@ class HTMLPlugin(base.BaseFormatter):
                 errs
             ))
             for err in errors:
-                line = unicode(  # NOQA
-                    err.physical_line.strip('\n').strip(' '), 'utf8'
-                ).encode('ascii', 'ignore')
                 print('%s:%d:%d %s %s' % (
                     err.filename, err.line_number, err.column_number,
-                    line, err.text
+                    err.code, err.text
                 ))
         index.sort(key=lambda r: (r[0], -r[1], r[2]))
 

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -115,7 +115,7 @@ class HTMLPlugin(base.BaseFormatter):
         with open(filename, 'rb') as f:
             source = f.read()
 
-        orig_filename = filename
+        # orig_filename = filename
         filename = re.sub(r'^\./', '', filename)
 
         highest_sev = min(sev for e, sev in self.errors)
@@ -150,6 +150,14 @@ class HTMLPlugin(base.BaseFormatter):
                 unique_messages > 1 or any(e[2] > 1 for e in errs),
                 errs
             ))
+            for err in errors:
+                line = unicode(  # NOQA
+                    err.physical_line.strip('\n').strip(' '), 'utf8'
+                ).encode('ascii', 'ignore')
+                print('%s:%d:%d %s %s' % (
+                    err.filename, err.line_number, err.column_number,
+                    line, err.text
+                ))
         index.sort(key=lambda r: (r[0], -r[1], r[2]))
 
         scores = []
@@ -157,7 +165,7 @@ class HTMLPlugin(base.BaseFormatter):
             scores.append(
                 '%s: %d' % (SEVERITY_NAMES[sev - 1], count)
             )
-        print(orig_filename, "has issues:", *scores)
+        # print(orig_filename, "has issues:", *scores)
 
         # Build a mapping of errors by line
         by_line = defaultdict(Counter)

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -299,6 +299,6 @@ class HTMLPlugin(base.BaseFormatter):
         )
         options.add_option(
             '--htmlpep8',
-            help="Whether to create a pep8 report instead of the standard one",
+            help="Whether to print a pep8 report instead of the standard one",
             default=False
         )

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -266,6 +266,7 @@ class HTMLPlugin(base.BaseFormatter):
         options.add_option(
             '--htmldir',
             help="Directory in which to write HTML output.",
+            default="reports/flake-report"
         )
         options.add_option(
             '--htmltitle',

--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -13,6 +13,8 @@ import os.path
 import codecs
 import datetime
 import pkgutil
+import ConfigParser
+
 from operator import attrgetter
 from collections import namedtuple, Counter
 
@@ -29,6 +31,8 @@ jinja2_env = Environment(
 )
 jinja2_env.filters['sentence'] = lambda s: s[:1].upper() + s[1:]
 
+config = ConfigParser.RawConfigParser()
+config.read('setup.cfg')
 
 #: A sequence of error code prefixes
 #:
@@ -72,8 +76,12 @@ class HTMLPlugin(base.BaseFormatter):
         self.report_template = jinja2_env.get_template('file-report.html')
         self.source_template = jinja2_env.get_template('annotated-source.html')
         if not self.options.htmldir:
-            sys.exit('--htmldir must be given if HTML output is enabled')
-        self.outdir = self.options.htmldir
+            try:
+                self.outdir = config.get('flake8', 'htmldir')
+            except:
+                sys.exit('--htmldir must be given if HTML output is enabled')
+        else:
+            self.outdir = self.options.htmldir
         if not os.path.isdir(self.outdir):
             os.mkdir(self.outdir)
         self.files = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.4.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ test_requirements = [
 
 setup(
     name='flake8-html',
-    version='0.3.1',
+    version='0.4.0',
     description="Generate HTML reports of flake8 violations",
     long_description=readme + '\n\n' + history,
     author="Daniel Pope",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ test_requirements = [
 
 setup(
     name='flake8-html',
-    version='0.3.0',
+    version='0.3.1',
     description="Generate HTML reports of flake8 violations",
     long_description=readme + '\n\n' + history,
     author="Daniel Pope",


### PR DESCRIPTION
## Config file support
I wanted this to run with django-jenkins flake8 task, but as it required cli options it was quite impossible. So I added config file parsing of the most common config files (setup.cfg, tox.ini, .flake8) to accommodate that need.

## CI support
When running the django-jenkins flake8 task with flake-html it would render a report, but the format was off. It generates a report from the out stream from flake8 and the outstream was in the format
```{file} has issues: high: x medium: x```
for each file while I needed a pep8 report which goes:
```{file}:{error line}:{error column} {error code} {error text}```
for each error.

So I added the option to output a pep8 report.

## Results
- Added benefit of reading config from a config file
- Running with django jenkins flake8 runner works and renders both html report and pep8 reports. The report itself is generated from the printed output, so in fact the only difference is that it outputs the compatible report to the cli rather than just how many issues each file has.
- Using the pep8 report changes is optional, as their operation is dependent on the values in config files/options. So it should work totally the same running it without using the htmlpep8 option or config value.