### PR TITLE
Add a framework classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     keywords='flake8 html',
     classifiers=[
         'Development Status :: 4 - Beta',
+        'Framework :: Flake8',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',


### PR DESCRIPTION
Warehouse (pypi.org) allows search results to be filtered by trove classifiers.
One such classifier is `Framework`, which accepts `Flake8` as a value. Setting
the classifier should help people find flake8-comprehensions when searching for
flake8 plugins.