### PR TITLE
Update plugin.py file

### DIFF
--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -97,6 +97,10 @@ class HTMLPlugin(base.BaseFormatter):
 
     def finished(self, filename):
         """Write the HTML reports for filename."""
+
+        # Normalize the filename path
+        filename = os.path.normpath(filename)
+
         report_filename = self.get_report_filename(filename, suffix='.report')
         source_filename = self.get_report_filename(filename, suffix='.source')
 


### PR DESCRIPTION
Normalize the filename path in order to fix the report filename path on Windows machine.
Initially the command worked only on a Linux machine.

Fixes #14 