### PR TITLE
Adjustments for flake8 3.8.x

### DIFF
--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -13,6 +13,7 @@ import os.path
 import codecs
 import datetime
 import pkgutil
+import sys
 
 from operator import attrgetter
 from collections import namedtuple, Counter
@@ -23,6 +24,11 @@ from pygments.lexers import PythonLexer
 from pygments.formatters import HtmlFormatter
 from flake8.formatting import base
 from jinja2 import Environment, PackageLoader, Markup
+
+if sys.version_info >= (3, 8):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
 
 
 jinja2_env = Environment(
@@ -66,6 +72,9 @@ IndexEntry = namedtuple(
 
 class HTMLPlugin(base.BaseFormatter):
     """A plugin for flake8 to render errors as HTML reports."""
+
+    name = 'flake8-html'
+    version = importlib_metadata.version('flake8-html')
 
     def after_init(self):
         """Configure the plugin run."""

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'jinja2>=2.9.0',
     'pygments>=2.2.0',
-    'flake8>=3.3.0'
+    'flake8>=3.3.0',
+    'importlib-metadata;python_version<"3.8"',
 ]
 
 test_requirements = [

--- a/tests/test_flake8_html.py
+++ b/tests/test_flake8_html.py
@@ -49,8 +49,9 @@ def chdir(dest):
 
 def test_report(bad_sourcedir, tmpdir):
     """Test that a report on a bad file creates the expected files."""
-    with chdir(bad_sourcedir):
+    with chdir(bad_sourcedir), pytest.raises(SystemExit) as excinfo:
         main(['--exit-zero', '--format=html', '--htmldir=%s' % tmpdir, '.'])
+    assert excinfo.value.code == 0
     names = ('index.html', 'styles.css', 'bad.report.html', 'bad.source.html')
     written = os.listdir(str(tmpdir))
     for n in names:


### PR DESCRIPTION
reported in flake8: https://gitlab.com/pycqa/flake8/-/issues/642

this plugin was missing two plugin attributes (`name` and `version`) -- after adding these `flake8-html` can benefit from the new grouped help:

```console
$ flake8 --help

...

flake8-html:
  --htmldir HTMLDIR     Directory in which to write HTML output.
  --htmltitle HTMLTITLE
                        Title to display in HTML documentation
  --htmlpep8 HTMLPEP8   Whether to print a pep8 report instead of the standard
                        one

...
```