### PR TITLE
Make the `find_severity` part of the public API

### DIFF
--- a/flake8_html/__init__.py
+++ b/flake8_html/__init__.py
@@ -6,8 +6,8 @@ __email__ = 'mauve@mauveweb.co.uk'
 __version__ = '0.4.1'
 
 
-from .plugin import HTMLPlugin
+from .plugin import HTMLPlugin, find_severity
 
 __all__ = (
-    'HTMLPlugin',
+    'HTMLPlugin', 'find_severity'
 )


### PR DESCRIPTION
Fixes #20

This is for tools such as [`genbadge`](https://github.com/smarie/python-genbadge) to get the same level of severity as `flake8_html` from the `flake8` codes