### PR TITLE
Use markupsafe.Markup instead of jinja2.Markup

### DIFF
--- a/flake8_html/plugin.py
+++ b/flake8_html/plugin.py
@@ -22,7 +22,8 @@ from collections import defaultdict
 from pygments.lexers import PythonLexer
 from pygments.formatters import HtmlFormatter
 from flake8.formatting import base
-from jinja2 import Environment, PackageLoader, Markup
+from jinja2 import Environment, PackageLoader
+from markupsafe import Markup
 
 if sys.version_info >= (3, 8):
     import importlib.metadata as importlib_metadata

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'jinja2>=2.9.0',
+    'jinja2>=3.1.0',
     'pygments>=2.2.0',
     'flake8>=3.3.0',
     'importlib-metadata;python_version<"3.8"',


### PR DESCRIPTION
The usage of jinja2.Markup was deprecated but still kept for compatibility on jinja2. 
It seems that they completely removed it on 3.0.1 as shown in the [changelog](https://jinja.palletsprojects.com/en/3.0.x/changes/#version-3-0-1)
As the dependency is not pinned to 2.9.0, it started failing lately on the builds with the following message:
```
flake8.exceptions.FailedToLoadPlugin: Flake8 failed to load plugin "html" due to cannot import name 'Markup' from 'jinja2' (/usr/local/lib/python3.10/site-packages/jinja2/__init__.py).
```
This PR fixes it, by importing Markup from markupsafe.