### PR TITLE
#22 add option to generate one-page report

### DIFF
--- a/flake8_html/templates/annotated-source-content.html
+++ b/flake8_html/templates/annotated-source-content.html
@@ -1,0 +1,37 @@
+<div id="source-{{ filename_url_safe }}" class="source page">
+    <h1>
+        {% if self_contained %}
+        <a href="#" onclick="switchToPage('{{ filename_url_safe }}', {{ highest_sev }})">
+        {% else %}
+        <a href="{{ report_filename }}">
+        {% endif %}
+            <img src="{{ 'data:image/svg+xml;utf-8,'+back_svg_data if self_contained else 'back.svg' }}"
+                 alt="&#x2B05;">
+            {{filename}} source
+        </a>
+    </h1>
+
+    <div id="doc">
+        {% for line in html_lines -%}
+        {%- set line_errors = errors[loop.index] -%}
+        {%- set line_sev = line_sevs[loop.index] -%}
+        <div id="l{{ loop.index }}"
+             class="code sev-{{ line_sev }} {% if line_errors %} le{% endif %}">
+            {%- if line_errors %}
+            <ul class="violations">
+                {% for (sev, code, text), count in line_errors.items() %}
+                <li>
+                    <span class="count sev-{{ sev }}">
+                       {{ code }}
+                    </span>
+                    {{ text|sentence }}
+                    {%- if count > 1 %} (in {{ count }} places){% endif -%}
+                </li>
+                {% endfor %}
+            </ul>
+            {%- endif -%}
+            <tt><i>{{loop.index}}</i> {{ line or '&nbsp;'|safe }}</tt>
+        </div>
+        {% endfor %}
+    </div>
+</div>

--- a/flake8_html/templates/annotated-source.html
+++ b/flake8_html/templates/annotated-source.html
@@ -1,43 +1,7 @@
-<!DOCTYPE html>
-<html>
-   <head>
-      <title>{{ filename }} - flake8 annotated source</title>
-      <meta http-equiv="Content-Type" value="text/html; charset=UTF-8">
-      <link rel="stylesheet" href="styles.css">
-   </head>
-   <body>
-      <div id="masthead" class="sev-{{ highest_sev }}"></div>
-      <div id="page">
-         <h1>
-            <a href="{{ report_filename }}">
-               <img src="back.svg" alt="&#x2B05;">
-               {{filename}} source
-            </a>
-         </h1>
+{% extends "base.html" %}
 
-         <div id="doc">
-            {% for line in html_lines -%}
-            {%- set line_errors = errors[loop.index] -%}
-            {%- set line_sev = line_sevs[loop.index] -%}
-            <div id="l{{ loop.index }}"
-               class="code sev-{{ line_sev }} {% if line_errors %} le{% endif %}">
-               {%- if line_errors %}
-               <ul class="violations">
-               {% for (sev, code, text), count in line_errors.items() %}
-                  <li>
-                     <span class="count sev-{{ sev }}">
-                        {{ code }}
-                     </span>
-                     {{ text|sentence }}
-                     {%- if count > 1 %} (in {{ count }} places){% endif -%}
-                  </li>
-               {% endfor %}
-               </ul>
-               {%- endif -%}
-               <tt><i>{{loop.index}}</i> {{ line or '&nbsp;'|safe }}</tt>
-            </div>
-            {% endfor %}
-         </div>
-      </div>
-   </body>
-</html>
+{% block title %}{{ filename }} - flake8 annotated source{% endblock %}
+
+{% block content %}
+{% include "annotated-source-content.html" %}
+{% endblock %}

--- a/flake8_html/templates/base.html
+++ b/flake8_html/templates/base.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    {% block head %}
+        <title>{% block title %}{% endblock %}</title>
+        <meta http-equiv="Content-Type" value="text/html; charset=UTF-8">
+
+        {% if self_contained %}
+        <style>{{ rendered_css }}</style>
+        {% else %}
+        <link rel="stylesheet" href="styles.css">
+        {% endif %}
+
+        {% block script %}
+        {% endblock %}
+
+    {% endblock %}
+    </head>
+    <body>
+        <div id="masthead" class="sev-{{ highest_sev }}" data-sev="{{ highest_sev }}"></div>
+        {% block content %}
+        {% endblock %}
+    </body>
+</html>

--- a/flake8_html/templates/bind-handler.js
+++ b/flake8_html/templates/bind-handler.js
@@ -1,0 +1,25 @@
+function bindHandler(link) {
+    var code = link.getAttribute('data-code');
+    var key = location.pathname + '#' + code;
+
+    var ul = link.parentNode.querySelector('.details');
+    if (sessionStorage[key] != 'open') {
+        ul.style.display = 'none';
+    }
+    link.addEventListener('click', function(event) {
+        if (!ul.style.display || ul.style.display == 'none') {
+            ul.style.display = 'block';
+            sessionStorage[key] = 'open';
+        } else {
+            ul.style.display = 'none';
+            sessionStorage[key] = 'closed';
+        }
+    });
+}
+
+window.addEventListener('DOMContentLoaded', function() {
+    var links = document.querySelectorAll('.file-report > #index > li > a');
+    for (var i = 0; i < links.length; i++) {
+        bindHandler(links[i]);
+    }
+});

--- a/flake8_html/templates/file-report-content.html
+++ b/flake8_html/templates/file-report-content.html
@@ -1,0 +1,53 @@
+<div id="{{ filename_url_safe }}" class="file-report page">
+    <p id="srclink">
+        {% if self_contained %}
+        <a title="View full annotated source"
+           href="#" onclick="switchToPage('source-{{ filename_url_safe }}', {{ highest_sev }})">
+        {% else %}
+        <a title="View full annotated source"
+           href="{{ source_filename }}">
+        {% endif %}
+            <img src="{{ 'data:image/svg+xml;utf-8,'+file_svg_data if self_contained else 'file.svg' }}"
+                 alt="&#x2261;">
+        </a>
+    </p>
+    <h1>
+        {% if self_contained %}
+        <a href="#" onclick="switchToPage('index-page')">
+        {% else %}
+        <a href="index.html">
+        {% endif %}
+            <img src="{{ 'data:image/svg+xml;utf-8,'+back_svg_data if self_contained else 'back.svg' }}"
+                 alt="&#x2B05;">
+            {{ filename }}
+        </a>
+    </h1>
+
+    <ul id="index">
+        {% for sev, count, code, text, line, msg_count, expand, errs in index %}
+        <li>
+            <a data-code="{{ code }}">
+                <span class="count sev-{{ sev }}">
+                   {{ count }}
+                </span>
+                <strong>{{ code }}:</strong> {{ text }}
+                {% if msg_count > 1 %}
+                (and {{ msg_count - 1 }} similar)
+                {% endif %}
+            </a>
+            <ul class="details">
+                {% for lineno, etext, count in errs -%}
+                <li>
+                    {% if expand %}
+                    <p>{{etext|sentence}}{% if count > 1 %} (in {{ count }} places){% endif %}:</p>
+                    {% endif %}
+                    <a href="{{ source_filename }}#l{{ lineno }}">
+                        <tt><i>{{lineno}}</i> {{ html_lines[lineno - 1] or '&nbsp;'|safe }}</tt>
+                    </a>
+                </li>
+                {%- endfor %}
+            </ul>
+        </li>
+        {% endfor %}
+    </ul>
+</div>

--- a/flake8_html/templates/file-report.html
+++ b/flake8_html/templates/file-report.html
@@ -1,79 +1,11 @@
-<!DOCTYPE html>
-<html>
-   <head>
-      <title>flake8 violations: {{ filename }}</title>
-      <meta http-equiv="Content-Type" value="text/html; charset=UTF-8">
-      <link rel="stylesheet" href="styles.css">
-<script>
-function bindHandler(link) {
-   var code = link.getAttribute('data-code');
-   var key = location.pathname + '#' + code;
+{% extends "base.html" %}
 
-   var ul = link.parentNode.querySelector('.details');
-   if (sessionStorage[key] != 'open') {
-      ul.style.display = 'none';
-   }
-   link.addEventListener('click', function (event) {
-      if (!ul.style.display || ul.style.display == 'none') {
-         ul.style.display = 'block';
-         sessionStorage[key] = 'open';
-      } else {
-         ul.style.display = 'none';
-         sessionStorage[key] = 'closed';
-      }
-   });
-}
+{% block title %}flake8 violations: {{ filename }}{% endblock %}
 
-window.addEventListener('DOMContentLoaded', function () {
-   var links = document.querySelectorAll('#index > li > a');
-   for (var i = 0; i < links.length; i++) {
-      bindHandler(links[i]);
-   }
-});
-</script>
-   </head>
-   <body>
-      <div id="masthead" class="sev-{{ highest_sev }}"></div>
-      <div id="page">
-         <p id="srclink">
-            <a title="View full annotated source"
-               href="{{ source_filename }}">
-               <img src="file.svg" alt="&#x2261;">
-            </a></p>
-         <h1>
-            <a href="index.html">
-               <img src="back.svg" alt="&#x2B05;">
-               {{ filename }}
-            </a>
-         </h1>
+{% block script %}
+<script>{% include "bind-handler.js" %}</script>
+{% endblock %}
 
-         <ul id="index">
-         {% for sev, count, code, text, line, msg_count, expand, errs in index %}
-         <li>
-            <a data-code="{{ code }}">
-               <span class="count sev-{{ sev }}">
-                  {{ count }}
-               </span>
-               <strong>{{ code }}:</strong> {{ text }}
-               {% if msg_count > 1 %}
-                  (and {{ msg_count - 1 }} similar)
-               {% endif %}
-            </a>
-            <ul class="details">
-            {% for lineno, etext, count in errs -%}
-            <li>
-               {% if expand %}
-               <p>{{etext|sentence}}{% if count > 1 %} (in {{ count }} places){% endif %}:</p>
-               {% endif %}
-               <a href="{{ source_filename }}#l{{ lineno }}">
-                  <tt><i>{{lineno}}</i> {{ html_lines[lineno - 1] or '&nbsp;'|safe }}</tt>
-               </a>
-            </li>
-            {%- endfor %}
-            </ul>
-         </li>
-         {% endfor %}
-         </ul>
-      </div>
-   </body>
-</html>
+{% block content %}
+{% include "file-report-content.html" %}
+{% endblock %}

--- a/flake8_html/templates/index.html
+++ b/flake8_html/templates/index.html
@@ -1,39 +1,55 @@
-<!DOCTYPE html>
-<html>
-   <head>
-      <title>{{ title }}</title>
-      <meta http-equiv="Content-Type" value="text/html; charset=UTF-8">
-      <link rel="stylesheet" href="styles.css">
-   </head>
-   <body>
-      <div id="masthead" class="sev-{{ highest_sev }}"></div>
-      <div id="page">
-          <h1>{{ title }}</h1>
-         <p id="versions">Generated on {{ now.strftime('%Y-%m-%d %H:%M') }}
-            with {{ versions }}
-         </p>
-         <ul id="index">
-         {% for e in index %}
-         <li>
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block script %}
+    {% if self_contained %}
+        <script>{% include "bind-handler.js" %}</script>
+        <script>{% include "self-contained.js" %}</script>
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+
+<div id="index-page" class="page">
+    <h1>{{ title }}</h1>
+    <p id="versions">Generated on {{ now.strftime('%Y-%m-%d %H:%M') }}
+        with {{ versions }}
+    </p>
+    <ul id="index">
+        {% for e in index %}
+        <li>
+            {% if self_contained %}
+            <a href="#" onclick="switchToPage('{{ e.filename_url_safe }}', {{ e.highest_sev }})">
+            {% else %}
             <a href="{{ e.report_name }}">
-               <span class="count sev-{{ e.highest_sev }}">
+            {% endif %}
+                <span class="count sev-{{ e.highest_sev }}">
                   {{ e.error_count }}
-               </span>
-               {{ e.filename }}
+                </span>
+                {{ e.filename }}
             </a>
-         </li>
-         {% else %}
-         <li>
+        </li>
+        {% else %}
+        <li>
             <div id="all-good">
                <span class="count sev-4">
                   <span class="tick">&#x2713;</span>
                </span>
-               <h2>All good!</h2>
-               <p>No flake8 errors found in {{ file_count }} files scanned.</p>
+                <h2>All good!</h2>
+                <p>No flake8 errors found in {{ file_count }} files scanned.</p>
             </div>
-         </li>
-         {% endfor %}
-         </ul>
-      </div>
-   </body>
-</html>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+
+{% if self_contained %}
+    {% for e in index %}
+        {{ e.report_rendered }}
+        {{ e.source_rendered }}
+    {% endfor %}
+{% endif %}
+
+{% endblock %}
+

--- a/flake8_html/templates/self-contained.js
+++ b/flake8_html/templates/self-contained.js
@@ -1,0 +1,29 @@
+function hideAllPages() {
+    for (const s of document.getElementsByClassName("page")) {
+        s.style.display = "none";
+    }
+}
+
+function changePageSev(sev = null) {
+    var head = document.getElementById('masthead');
+    if (sev === null) {
+        sev = head.dataset['sev'];
+    }
+    head.className = 'sev-' + sev;
+}
+
+function switchToPage(pageId, highestSev = null) {
+    hideAllPages();
+    changePageSev(highestSev);
+    var htmlShow = document.getElementById(pageId);
+    if (htmlShow.style.display === "none") {
+        htmlShow.style.display = "block";
+    } else {
+        htmlShow.style.display = "none";
+    }
+}
+
+window.addEventListener('DOMContentLoaded', function() {
+    hideAllPages();
+    switchToPage('index-page');
+});

--- a/flake8_html/templates/styles.css
+++ b/flake8_html/templates/styles.css
@@ -9,6 +9,7 @@ html {
    top: 0;
    right: 0;
    height: 40%;
+   z-index: -1;
 }
 
 h1, h2 {
@@ -38,7 +39,7 @@ h1 a {
    color: rgba(255, 255, 255, 0.7);
 }
 
-#page {
+.page {
    position: relative;
    max-width: 960px;
    margin: 0 auto;

--- a/tests/test_flake8_html.py
+++ b/tests/test_flake8_html.py
@@ -56,3 +56,14 @@ def test_report(bad_sourcedir, tmpdir):
     written = os.listdir(str(tmpdir))
     for n in names:
         assert n in written, "File %s not written" % n
+
+
+def test_self_contained_report(bad_sourcedir, tmpdir):
+    """Test that a report on a bad file creates self-contained file."""
+    with chdir(bad_sourcedir), pytest.raises(SystemExit) as excinfo:
+        main(['--exit-zero', '--format=html', '--htmldir=%s' % tmpdir, '--self-contained-html', '.'])
+    assert excinfo.value.code == 0
+    names = ('index.html', )
+    written = os.listdir(str(tmpdir))
+    for n in names:
+        assert n in written, "File %s not written" % n


### PR DESCRIPTION
Summary: https://github.com/lordmauve/flake8-html/issues/22

Approach:
- added `--self-contained-html` option as a marker to understand whether need to write one or multiple HTML files
- `back.svg` and `file.svg` files passes as [https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs](Data URLs) to one-page report
- report and source HTML files will be in the same one-page report. Navigation is done in `self-contained.js` by hiding elements with `page` classes.


- redesigned Jinja's templates:
1. `base.html` is a base for every template (index, reports, sources)
2. `index.html` now has additional logic based on `self_contained` marker
3. `file-report.html` and `annotated-source.html` are used for usual reports without `--self-contained-html` option
4. `file-report-content.html` and `annotated-source-content.html` are used both for usual and one-page report. Usual report uses them as template to fill, one-page report uses them to fill `index.html` template
5. `bind-handler.js` contains JS script from `file-report.html` in order to reuse it in different template