### PR TITLE
CI: Fix Windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Install package and dependencies
       run: |
         python -m pip install pip-tools
-        pip-sync requirements_dev.txt
+        python -m piptools sync requirements_dev.txt
         python -m pip install -e .
 
     - name: Run pytest


### PR DESCRIPTION
On Windows, one cannot overwrite an executable file which is currently executing. That's, however, exactly what `pip-sync` might try to do at some points, and indeed the CI runs were failing due to that:
```
   Attempting uninstall: pip-tools
     Found existing installation: pip-tools 6.10.0
     Uninstalling pip-tools-6.10.0:
       Successfully uninstalled pip-tools-6.10.0
 ERROR: Could not install packages due to an OSError: [WinError 5] Access is denied: 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pip-uninstall-8ii4ro6b\\pip-sync.exe'
 Consider using the `--user` option or check the permissions.

 Traceback (most recent call last):
   File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\runpy.py", line 194, in _run_module_as_main
     return _run_code(code, main_globals, None,
   File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\runpy.py", line 87, in _run_code
     exec(code, run_globals)
   File "C:\hostedtoolcache\windows\Python\3.8.10\x64\Scripts\pip-sync.exe\__main__.py", line 7, in <module>
   File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\click\core.py", line 1130, in __call__
     return self.main(*args, **kwargs)
   File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\click\core.py", line 1055, in main
     rv = self.invoke(ctx)
   File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\click\core.py", line 1404, in invoke
     return ctx.invoke(self.callback, **ctx.params)
   File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\click\core.py", line 760, in invoke
     return __callback(*args, **kwargs)
   File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\piptools\scripts\sync.py", line 177, in cli
     to_uninstall,
   File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\piptools\sync.py", line 240, in sync
     req_lines.append(format_requirement(ireq, hashes=ireq_hashes))
   File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\subprocess.py", line 516, in run
     raise CalledProcessError(retcode, process.args,
 subprocess.CalledProcessError: Command '['C:\\hostedtoolcache\\windows\\Python\\3.8.10\\x64\\python.exe', '-m', 'pip', 'install', '-r', 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmpbe8tk3qm']' returned non-zero exit status 1.
```
Solve this by not executing `pip-sync` directly, but instead going through the Python interpreter and invoking the module from there.

I think this used to work previously because there was (probably) no version change to take care of. Now there's apparently some discrepancy.

Bug: https://github.com/jazzband/pip-tools/issues/478